### PR TITLE
Add i18n support for French and English

### DIFF
--- a/components/AboutMe.vue
+++ b/components/AboutMe.vue
@@ -10,10 +10,10 @@
         :class="{ 'animate-fade-in-left': isSectionVisible }"
       >
         <h2 class="text-3xl text-primary font-extrabold uppercase">
-          About me
+          {{ $t('aboutMe.title') }}
         </h2>
         <h3 class="text-2xl lg:text-3xl font-extrabold lg:w-3/4">
-          Full-Stack Developer based in Toulouse, France 🇫🇷📍
+          {{ $t('aboutMe.subtitle') }}
         </h3>
       </div>
 
@@ -22,46 +22,44 @@
         :class="{ 'animate-fade-in-right': isSectionVisible }"
       >
         <p>
-          My name is Quentin Aslan, and I'm a <strong>25-year-old Full-Stack software engineer</strong>. My passion for technology started in my adolescence, and I've been developing professional websites since 2015.
+          {{ $t('aboutMe.description') }}
         </p>
 
         <h3 class="text-xl font-semibold">
-          International Experience
+          {{ $t('aboutMe.internationalExperience') }}
         </h3>
         <p>
-          Originally from France <span aria-label="France flag">🇫🇷</span>, I spent the last two years living in Canada <span aria-label="Canada flag">🇨🇦</span>
-          (2022–September 2024) to gain international experience.
+          {{ $t('aboutMe.internationalExperienceDescription') }}
         </p>
 
         <p>
-          This journey also took me to Boston, USA <span aria-label="USA flag">🇺🇸</span> to solidify my fluency in English.
+          {{ $t('aboutMe.usaExperience') }}
         </p>
 
         <p>
-          Additionally, I’ve had the opportunity to enhance and practice my Spanish during stays in Colombia
-          <span aria-label="Colombia flag">🇨🇴</span> and Guatemala <span aria-label="Guatemala flag">🇬🇹</span>.
+          {{ $t('aboutMe.spanishExperience') }}
         </p>
 
         <h3 class="text-xl font-semibold">
-          Expertise in Development
+          {{ $t('aboutMe.expertise') }}
         </h3>
         <p>
-          As a full-stack software engineer, I specialize in developing <span class="font-semibold">websites and mobile applications 📱</span>.
+          {{ $t('aboutMe.expertiseDescription') }}
         </p>
 
         <p>
-          My expertise extends to <span class="font-semibold">network management</span> and <span class="font-semibold">Linux system administration</span>.
+          {{ $t('aboutMe.networkManagement') }}
         </p>
 
         <h3 class="text-xl font-semibold">
-          Passion for Collaboration and Learning
+          {{ $t('aboutMe.collaboration') }}
         </h3>
         <p>
-          I thrive in collaborative environments, working closely with cross-functional teams to deliver robust, user-friendly solutions.
+          {{ $t('aboutMe.collaborationDescription') }}
         </p>
 
         <p>
-          Passionate about continuous learning and new technologies, I aim to create impactful and innovative software.
+          {{ $t('aboutMe.learning') }}
         </p>
       </div>
     </div>

--- a/components/Contact.vue
+++ b/components/Contact.vue
@@ -21,18 +21,18 @@
     >
       <div class="flex flex-col gap-2 items-center text-center lg:w-2/4">
         <h2 class="text-3xl text-primary font-extrabold uppercase">
-          Contact
+          {{ $t('contact.title') }}
         </h2>
       </div>
 
       <a
         href="mailto:quentin.aslan@outlook.com"
         class="text-2xl lg:text-3xl font-bold text-gray-700 duration-150 hover:underline hover:text-primary hover:-translate-y-1.5"
-      >quentin.aslan@outlook.com</a>
+      >{{ $t('contact.email') }}</a>
       <a
         href="tel:+33652689583"
         class="text-2xl lg:text-3xl font-bold text-gray-700 duration-150 hover:underline hover:text-primary hover:-translate-y-1.5"
-      >+33 6 52 68 95 83</a>
+      >{{ $t('contact.phone') }}</a>
 
       <div class="flex flex-row items-center justify-center gap-10">
         <a

--- a/components/Experience.vue
+++ b/components/Experience.vue
@@ -76,7 +76,7 @@
         class="text-right"
       >
         <button class="text-secondary font-semibold duration-150 group-hover:border-b-2 group-hover:border-secondary hover:text-primary hover:border-primary hover:-translate-y-1.5">
-          {{ isAllVisible ? 'Show less' : 'Show more' }}
+          {{ isAllVisible ? $t('experience.showLess') : $t('experience.showMore') }}
         </button>
       </div>
     </div>

--- a/components/Experiences.vue
+++ b/components/Experiences.vue
@@ -6,7 +6,7 @@
   >
     <header>
       <h2 class="text-3xl font-extrabold text-primary uppercase text-center">
-        Professional Experience
+        {{ $t('experiences.title') }}
       </h2>
     </header>
 

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,9 +1,6 @@
 <template>
   <footer class="flex items-center justify-between bg-zinc-700 text-white py-4 px-5  lg:px-20 h-40">
-    <span class="max-w-[40%] lg:max-w-full text-xs lg:text-lg">Copyright © {{ new Date().getFullYear() }}. All rights are reserved.</span>
-    <span class="max-w-[40%] lg:max-w-full text-xs lg:text-lg">Developed by <a
-      href="https://quentinaslan.fr"
-      class="font-bold cursor-pointer hover:underline"
-    >Quentin Aslan</a> 😃</span>
+    <span class="max-w-[40%] lg:max-w-full text-xs lg:text-lg">{{ $t('footer.copyright', { year: new Date().getFullYear() }) }}</span>
+    <span class="max-w-[40%] lg:max-w-full text-xs lg:text-lg">{{ $t('footer.developedBy') }}</span>
   </footer>
 </template>

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -33,13 +33,13 @@
 
         <div class="animate-fade-in-left-slow flex flex-col text-center lg:text-left gap-2 w-4/5">
           <h1 class="text-4xl lg:text-6xl font-bold text-[#00549A] ">
-            Software <br> Engineer <span
+            {{ $t('hero.title') }} <span
               ref="waveEl"
               class="inline-block transform origin-bottom hover:animate-wave cursor-pointer"
             >👋</span>
           </h1>
           <p class="mt-2 text-xl text-gray-600 leading-8">
-            Hi, I'm <strong>Quentin Aslan</strong>, <br> A passionate <strong>Full-Stack Developer.</strong>
+            {{ $t('hero.subtitle') }}
           </p><p />
 
           <div class="flex flex-row items-center justify-center lg:justify-normal gap-5">

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -14,12 +14,23 @@
           </li>
         </ul>
       </nav>
+      <div class="flex space-x-4">
+        <button
+          v-for="locale in locales"
+          :key="locale.code"
+          @click="switchLocale(locale.code)"
+          :class="['text-primary transition-colors duration-300 hover:text-secondary', { 'font-bold': locale.code === currentLocale }]"
+        >
+          {{ locale.code.toUpperCase() }}
+        </button>
+      </div>
     </div>
   </header>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 const isScrolled = ref(false)
 
@@ -42,6 +53,14 @@ const navLinks = [
   { text: 'Contact', href: '#contact' },
   // { text: 'Articles', href: '/articles' },
 ]
+
+const { locale, locales } = useI18n()
+
+const currentLocale = locale.value
+
+const switchLocale = (code: string) => {
+  locale.value = code
+}
 </script>
 
 <style scoped>

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -28,7 +28,7 @@
         <Card :class="['flex flex-col w-full']">
           <div>
             <h4 class="text-xl text-primary font-semibold group-hover:font-bold">
-              Tech Stack:
+              {{ $t('projectCard.techStack') }}
             </h4>
           </div>
           <template #content>

--- a/components/TheProjectsList.vue
+++ b/components/TheProjectsList.vue
@@ -6,7 +6,7 @@
   >
     <header class="text-center">
       <h2 class="text-3xl font-extrabold text-primary">
-        Some of my projects 🤠
+        {{ $t('projectsList.title') }}
       </h2>
     </header>
 
@@ -15,17 +15,17 @@
         :class="getCardAlignment(1)"
         :tech-stack="easyRouterTechStack"
         :images="easyRouterImages"
-        title="Router Easy 🛜"
-        role="Full-Stack Developer"
-        date="2024"
-        location="I was at Boston, USA 🇺🇸"
+        :title="$t('projectsList.easyRouter.title')"
+        :role="$t('projectsList.easyRouter.role')"
+        :date="$t('projectsList.easyRouter.date')"
+        :location="$t('projectsList.easyRouter.location')"
       >
         <template #main-description>
-          The Easy Router Project is a <strong>web application designed to simplify the configuration of a travel router setup on a Raspberry Pi</strong>.
+          {{ $t('projectsList.easyRouter.mainDescription') }}
         </template>
 
         <template #sub-description>
-          <EasyRouterSubDescription />
+          {{ $t('projectsList.easyRouter.subDescription') }}
         </template>
 
         <template #tablet-project-images="{ isSubDescriptionVisible }">
@@ -66,17 +66,17 @@
         :class="getCardAlignment(2)"
         :tech-stack="archerAffiliateTechStack"
         :images="archerAffiliateImages"
-        title="Archer Affiliate"
-        role="Frontend Developer"
-        date="2024"
-        location="I was at Boston, USA 🇺🇸"
+        :title="$t('projectsList.archerAffiliate.title')"
+        :role="$t('projectsList.archerAffiliate.role')"
+        :date="$t('projectsList.archerAffiliate.date')"
+        :location="$t('projectsList.archerAffiliate.location')"
       >
         <template #main-description>
-          A <strong>Chrome extension</strong> that adds <strong>React components</strong> to <strong>Amazon product pages</strong>, making it easy for users to create affiliate links for Archer Affiliate.
+          {{ $t('projectsList.archerAffiliate.mainDescription') }}
         </template>
 
         <template #sub-description>
-          <ArcherAffiliateSubDescription />
+          {{ $t('projectsList.archerAffiliate.subDescription') }}
         </template>
 
         <template #tablet-project-images>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,128 @@
+{
+  "navbar": {
+    "projects": "Projects",
+    "experiences": "Experiences",
+    "contact": "Contact"
+  },
+  "aboutMe": {
+    "title": "About me",
+    "subtitle": "Full-Stack Developer based in Toulouse, France 🇫🇷📍",
+    "description": "My name is Quentin Aslan, and I'm a <strong>25-year-old Full-Stack software engineer</strong>. My passion for technology started in my adolescence, and I've been developing professional websites since 2015.",
+    "internationalExperience": "International Experience",
+    "internationalExperienceDescription": "Originally from France <span aria-label=\"France flag\">🇫🇷</span>, I spent the last two years living in Canada <span aria-label=\"Canada flag\">🇨🇦</span> (2022–September 2024) to gain international experience.",
+    "usaExperience": "This journey also took me to Boston, USA <span aria-label=\"USA flag\">🇺🇸</span> to solidify my fluency in English.",
+    "spanishExperience": "Additionally, I’ve had the opportunity to enhance and practice my Spanish during stays in Colombia <span aria-label=\"Colombia flag\">🇨🇴</span> and Guatemala <span aria-label=\"Guatemala flag\">🇬🇹</span>.",
+    "expertise": "Expertise in Development",
+    "expertiseDescription": "As a full-stack software engineer, I specialize in developing <span class=\"font-semibold\">websites and mobile applications 📱</span>.",
+    "networkManagement": "My expertise extends to <span class=\"font-semibold\">network management</span> and <span class=\"font-semibold\">Linux system administration</span>.",
+    "collaboration": "Passion for Collaboration and Learning",
+    "collaborationDescription": "I thrive in collaborative environments, working closely with cross-functional teams to deliver robust, user-friendly solutions.",
+    "learning": "Passionate about continuous learning and new technologies, I aim to create impactful and innovative software."
+  },
+  "contact": {
+    "title": "Contact",
+    "email": "quentin.aslan@outlook.com",
+    "phone": "+33 6 52 68 95 83"
+  },
+  "experience": {
+    "period": "Period",
+    "role": "Role",
+    "company": "Company",
+    "location": "Location",
+    "keyAchievements": "Key Achievements",
+    "moreDetails": "More Details",
+    "showMore": "Show more",
+    "showLess": "Show less"
+  },
+  "experiences": {
+    "title": "Professional Experience",
+    "bell": {
+      "period": "2022 - 2024",
+      "role": "Frontend Engineer",
+      "company": "Bell",
+      "location": "Montréal, Canada 🇨🇦",
+      "keyAchievements": [
+        "<span class=\"text-primary font-semibold\">Led the complete redesign of a critical B2B application</span> for Bell, improving functionality and user experience.",
+        "<span class=\"text-primary font-semibold\">Developed a scalable and reusable frontend architecture</span> with VueJS 3 and Pinia.",
+        "<span class=\"text-primary font-semibold\">Enhanced proficiency in Figma</span> by working closely with UX design teams.",
+        "Successfully managed and collaborated in a large, cross-functional team using Agile methodologies.",
+        "Integrated advanced user tracking with Matomo, providing valuable insights into application usage."
+      ],
+      "moreDetails": [
+        "Worked closely with UX teams to ensure seamless integration of design and functionality.",
+        "Implemented unit testing and CI/CD pipelines to ensure code quality and efficient deployment",
+        "Collaborated with cross-functional teams to gather and implement feedback, improving the overall user experience.",
+        "Utilized Agile methodology to manage project timelines and deliverables effectively.",
+        "Conducted technical presentations to demonstrate new features and functionalities to stakeholders.",
+        "Technologies Used: VueJS 3, Pinia, SASS, Figma, Matomo, Java Spring, Azure DevOps, GitLab."
+      ]
+    },
+    "occitaline": {
+      "period": "2019 - 2022",
+      "role": "Software Engineer",
+      "company": "Occitaline",
+      "location": "Toulouse, France 🇫🇷",
+      "keyAchievements": [
+        "<span class=\"text-primary font-semibold\">Created an application for configuring Linux routers </span>, used by multiple companies including the <span class=\"text-primary font-semibold\">National Center for Space Research (CNES) in France</span> or <span class=\"text-primary font-semibold\">The France's stadium</span>.",
+        "<span class=\"text-primary font-semibold\">Designed and implemented REST APIs</span> with Node.js and integrated them with MongoDB.",
+        "Built responsive user interfaces using Vue.js, Bootstrap, and jQuery.",
+        "Implemented unit testing and CI/CD pipelines, ensuring robust and efficient development processes.",
+        "Managed the complete product development cycle, from requirements gathering to production deployment.",
+        "Developed a JavaScript-based 3D model viewer using the BIM (Building Information Modeling) approach."
+      ],
+      "moreDetails": [
+        "<span class=\"text-primary font-semibold\">Worked closely with UX teams</span> to ensure seamless integration of design and functionality.",
+        "<span class=\"text-primary font-semibold\">Implemented unit testing and CI/CD pipelines</span> to ensure code quality and efficient deployment 🚀.",
+        "<span class=\"text-primary font-semibold\">Collaborated with cross-functional teams</span> to gather and implement feedback, improving the overall user experience.",
+        "<span class=\"text-primary font-semibold\">Utilized Agile methodology</span> to manage project timelines and deliverables effectively.",
+        "<span class=\"text-primary font-semibold\">Conducted technical presentations</span> to demonstrate new features and functionalities to stakeholders.",
+        "<span class=\"text-primary font-semibold\">Technologies Used</span>: Vue.js 3, jQuery, HTML/CSS, Node.js GitLab."
+      ]
+    },
+    "freelance": {
+      "period": "2015 - 2022",
+      "role": "Freelance Software Engineer",
+      "company": "Various Clients",
+      "location": "Remote",
+      "keyAchievements": [
+        "REST APIs, Linux system administration, Network Management.",
+        "Intrusion testing, security auditing.",
+        "Mobile apps, E-commerce and showcase websites.",
+        "Web & Mobile application development for individuals and businesses."
+      ],
+      "moreDetails": []
+    }
+  },
+  "footer": {
+    "copyright": "Copyright © {{ year }}. All rights are reserved.",
+    "developedBy": "Developed by <a href=\"https://quentinaslan.fr\" class=\"font-bold cursor-pointer hover:underline\">Quentin Aslan</a> 😃"
+  },
+  "hero": {
+    "title": "Software Engineer",
+    "subtitle": "Hi, I'm <strong>Quentin Aslan</strong>, <br> A passionate <strong>Full-Stack Developer.</strong>",
+    "linkedin": "LinkedIn",
+    "github": "GitHub"
+  },
+  "projectCard": {
+    "techStack": "Tech Stack:"
+  },
+  "projectsList": {
+    "title": "Some of my projects 🤠",
+    "easyRouter": {
+      "title": "Router Easy 🛜",
+      "role": "Full-Stack Developer",
+      "date": "2024",
+      "location": "I was at Boston, USA 🇺🇸",
+      "mainDescription": "The Easy Router Project is a <strong>web application designed to simplify the configuration of a travel router setup on a Raspberry Pi</strong>.",
+      "subDescription": "The extension allows users to interact with a form on Amazon product pages, helping them create affiliate links directly from the product page. I also developed the extension’s popup, where users can log in and access the same React features found on the product page."
+    },
+    "archerAffiliate": {
+      "title": "Archer Affiliate",
+      "role": "Frontend Developer",
+      "date": "2024",
+      "location": "I was at Boston, USA 🇺🇸",
+      "mainDescription": "A <strong>Chrome extension</strong> that adds <strong>React components</strong> to <strong>Amazon product pages</strong>, making it easy for users to create affiliate links for Archer Affiliate.",
+      "subDescription": "For this project, I used <a href=\"https://docs.plasmo.com/\" target=\"_blank\" class=\"font-bold hover:underline\">Plasmo</a>, a great framework that makes building Chrome extensions easier, similar to <a href=\"https://nextjs.org/docs\" target=\"_blank\" class=\"font-bold hover:underline\">Next.js</a>, but designed for browser extensions."
+    }
+  }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,128 @@
+{
+  "navbar": {
+    "projects": "Projets",
+    "experiences": "Expériences",
+    "contact": "Contact"
+  },
+  "aboutMe": {
+    "title": "À propos de moi",
+    "subtitle": "Développeur Full-Stack basé à Toulouse, France 🇫🇷📍",
+    "description": "Je m'appelle Quentin Aslan, et je suis un <strong>ingénieur logiciel Full-Stack de 25 ans</strong>. Ma passion pour la technologie a commencé à l'adolescence, et je développe des sites web professionnels depuis 2015.",
+    "internationalExperience": "Expérience Internationale",
+    "internationalExperienceDescription": "Originaire de France <span aria-label=\"Drapeau de la France\">🇫🇷</span>, j'ai passé les deux dernières années au Canada <span aria-label=\"Drapeau du Canada\">🇨🇦</span> (2022–septembre 2024) pour acquérir une expérience internationale.",
+    "usaExperience": "Ce voyage m'a également conduit à Boston, USA <span aria-label=\"Drapeau des États-Unis\">🇺🇸</span> pour renforcer ma maîtrise de l'anglais.",
+    "spanishExperience": "De plus, j'ai eu l'opportunité d'améliorer et de pratiquer mon espagnol lors de séjours en Colombie <span aria-label=\"Drapeau de la Colombie\">🇨🇴</span> et au Guatemala <span aria-label=\"Drapeau du Guatemala\">🇬🇹</span>.",
+    "expertise": "Expertise en Développement",
+    "expertiseDescription": "En tant qu'ingénieur logiciel Full-Stack, je me spécialise dans le développement de <span class=\"font-semibold\">sites web et d'applications mobiles 📱</span>.",
+    "networkManagement": "Mon expertise s'étend à la <span class=\"font-semibold\">gestion de réseau</span> et à l'<span class=\"font-semibold\">administration des systèmes Linux</span>.",
+    "collaboration": "Passion pour la Collaboration et l'Apprentissage",
+    "collaborationDescription": "Je m'épanouis dans des environnements collaboratifs, travaillant en étroite collaboration avec des équipes interfonctionnelles pour fournir des solutions robustes et conviviales.",
+    "learning": "Passionné par l'apprentissage continu et les nouvelles technologies, je vise à créer des logiciels innovants et impactants."
+  },
+  "contact": {
+    "title": "Contact",
+    "email": "quentin.aslan@outlook.com",
+    "phone": "+33 6 52 68 95 83"
+  },
+  "experience": {
+    "period": "Période",
+    "role": "Rôle",
+    "company": "Entreprise",
+    "location": "Lieu",
+    "keyAchievements": "Principales Réalisations",
+    "moreDetails": "Plus de Détails",
+    "showMore": "Voir plus",
+    "showLess": "Voir moins"
+  },
+  "experiences": {
+    "title": "Expérience Professionnelle",
+    "bell": {
+      "period": "2022 - 2024",
+      "role": "Ingénieur Frontend",
+      "company": "Bell",
+      "location": "Montréal, Canada 🇨🇦",
+      "keyAchievements": [
+        "<span class=\"text-primary font-semibold\">Dirigé la refonte complète d'une application B2B critique</span> pour Bell, améliorant la fonctionnalité et l'expérience utilisateur.",
+        "<span class=\"text-primary font-semibold\">Développé une architecture frontend évolutive et réutilisable</span> avec VueJS 3 et Pinia.",
+        "<span class=\"text-primary font-semibold\">Amélioré la maîtrise de Figma</span> en travaillant en étroite collaboration avec les équipes UX.",
+        "Géré et collaboré avec succès dans une grande équipe interfonctionnelle utilisant des méthodologies Agile.",
+        "Intégré un suivi utilisateur avancé avec Matomo, fournissant des informations précieuses sur l'utilisation de l'application."
+      ],
+      "moreDetails": [
+        "Travaillé en étroite collaboration avec les équipes UX pour assurer une intégration transparente du design et de la fonctionnalité.",
+        "Implémenté des tests unitaires et des pipelines CI/CD pour garantir la qualité du code et un déploiement efficace",
+        "Collaboré avec des équipes interfonctionnelles pour recueillir et mettre en œuvre des retours, améliorant l'expérience utilisateur globale.",
+        "Utilisé la méthodologie Agile pour gérer les délais et les livrables du projet de manière efficace.",
+        "Réalisé des présentations techniques pour démontrer les nouvelles fonctionnalités aux parties prenantes.",
+        "Technologies Utilisées : VueJS 3, Pinia, SASS, Figma, Matomo, Java Spring, Azure DevOps, GitLab."
+      ]
+    },
+    "occitaline": {
+      "period": "2019 - 2022",
+      "role": "Ingénieur Logiciel",
+      "company": "Occitaline",
+      "location": "Toulouse, France 🇫🇷",
+      "keyAchievements": [
+        "<span class=\"text-primary font-semibold\">Créé une application pour configurer des routeurs Linux</span>, utilisée par plusieurs entreprises, y compris le <span class=\"text-primary font-semibold\">Centre National d'Études Spatiales (CNES) en France</span> ou <span class=\"text-primary font-semibold\">Le Stade de France</span>.",
+        "<span class=\"text-primary font-semibold\">Conçu et implémenté des API REST</span> avec Node.js et les a intégrées avec MongoDB.",
+        "Construit des interfaces utilisateur réactives en utilisant Vue.js, Bootstrap et jQuery.",
+        "Implémenté des tests unitaires et des pipelines CI/CD, garantissant des processus de développement robustes et efficaces.",
+        "Géré le cycle complet de développement du produit, de la collecte des exigences au déploiement en production.",
+        "Développé un visualiseur de modèle 3D basé sur JavaScript en utilisant l'approche BIM (Building Information Modeling)."
+      ],
+      "moreDetails": [
+        "<span class=\"text-primary font-semibold\">Travaillé en étroite collaboration avec les équipes UX</span> pour assurer une intégration transparente du design et de la fonctionnalité.",
+        "<span class=\"text-primary font-semibold\">Implémenté des tests unitaires et des pipelines CI/CD</span> pour garantir la qualité du code et un déploiement efficace 🚀.",
+        "<span class=\"text-primary font-semibold\">Collaboré avec des équipes interfonctionnelles</span> pour recueillir et mettre en œuvre des retours, améliorant l'expérience utilisateur globale.",
+        "<span class=\"text-primary font-semibold\">Utilisé la méthodologie Agile</span> pour gérer les délais et les livrables du projet de manière efficace.",
+        "<span class=\"text-primary font-semibold\">Réalisé des présentations techniques</span> pour démontrer les nouvelles fonctionnalités aux parties prenantes.",
+        "<span class=\"text-primary font-semibold\">Technologies Utilisées</span> : Vue.js 3, jQuery, HTML/CSS, Node.js GitLab."
+      ]
+    },
+    "freelance": {
+      "period": "2015 - 2022",
+      "role": "Ingénieur Logiciel Freelance",
+      "company": "Divers Clients",
+      "location": "À distance",
+      "keyAchievements": [
+        "API REST, administration des systèmes Linux, gestion de réseau.",
+        "Tests d'intrusion, audit de sécurité.",
+        "Applications mobiles, sites web de commerce électronique et vitrines.",
+        "Développement d'applications Web et mobiles pour particuliers et entreprises."
+      ],
+      "moreDetails": []
+    }
+  },
+  "footer": {
+    "copyright": "Copyright © {{ year }}. Tous droits réservés.",
+    "developedBy": "Développé par <a href=\"https://quentinaslan.fr\" class=\"font-bold cursor-pointer hover:underline\">Quentin Aslan</a> 😃"
+  },
+  "hero": {
+    "title": "Ingénieur Logiciel",
+    "subtitle": "Bonjour, je suis <strong>Quentin Aslan</strong>, <br> Un <strong>Développeur Full-Stack</strong> passionné.",
+    "linkedin": "LinkedIn",
+    "github": "GitHub"
+  },
+  "projectCard": {
+    "techStack": "Tech Stack :"
+  },
+  "projectsList": {
+    "title": "Quelques-uns de mes projets 🤠",
+    "easyRouter": {
+      "title": "Router Easy 🛜",
+      "role": "Développeur Full-Stack",
+      "date": "2024",
+      "location": "J'étais à Boston, USA 🇺🇸",
+      "mainDescription": "Le projet Easy Router est une <strong>application web conçue pour simplifier la configuration d'un routeur de voyage sur un Raspberry Pi</strong>.",
+      "subDescription": "L'extension permet aux utilisateurs d'interagir avec un formulaire sur les pages de produits Amazon, les aidant à créer des liens d'affiliation directement depuis la page produit. J'ai également développé le popup de l'extension, où les utilisateurs peuvent se connecter et accéder aux mêmes fonctionnalités React trouvées sur la page produit."
+    },
+    "archerAffiliate": {
+      "title": "Archer Affiliate",
+      "role": "Développeur Frontend",
+      "date": "2024",
+      "location": "J'étais à Boston, USA 🇺🇸",
+      "mainDescription": "Une <strong>extension Chrome</strong> qui ajoute des <strong>composants React</strong> aux <strong>pages de produits Amazon</strong>, facilitant la création de liens d'affiliation pour Archer Affiliate.",
+      "subDescription": "Pour ce projet, j'ai utilisé <a href=\"https://docs.plasmo.com/\" target=\"_blank\" class=\"font-bold hover:underline\">Plasmo</a>, un excellent framework qui facilite la création d'extensions Chrome, similaire à <a href=\"https://nextjs.org/docs\" target=\"_blank\" class=\"font-bold hover:underline\">Next.js</a>, mais conçu pour les extensions de navigateur."
+    }
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,3 @@
-// <script src="https://platform.linkedin.com/badges/js/profile.js" async defer type="text/javascript"></script>
-
 import Aura from '@primevue/themes/aura'
 
 export default defineNuxtConfig({
@@ -37,6 +35,7 @@ export default defineNuxtConfig({
     '@vueuse/nuxt',
     '@nuxt/eslint',
     '@primevue/nuxt-module',
+    '@nuxtjs/i18n', // P0f91
   ],
   eslint: {
     config: {
@@ -51,6 +50,18 @@ export default defineNuxtConfig({
       theme: {
         preset: Aura,
       },
+    },
+  },
+  i18n: { // Pf7d2
+    locales: [
+      { code: 'en', iso: 'en-US', file: 'en.json' },
+      { code: 'fr', iso: 'fr-FR', file: 'fr.json' }
+    ],
+    defaultLocale: 'en', // P0c43
+    lazy: true,
+    langDir: 'locales/',
+    vueI18n: {
+      fallbackLocale: 'en',
     },
   },
 })


### PR DESCRIPTION
Add internalization to the website, making it available in both French and English.

* **i18n Configuration**:
  - Add `@nuxtjs/i18n` to the modules array in `nuxt.config.ts`.
  - Configure i18n with locales for English and French.
  - Set default locale to English.

* **Language Switcher**:
  - Add a language switcher to the navigation bar in `components/Navbar.vue`.
  - Use `useI18n` to switch between languages.

* **Translation Files**:
  - Add `locales/en.json` with translations for all text content in English.
  - Add `locales/fr.json` with translations for all text content in French.

* **Component Updates**:
  - Replace static text with i18n keys for translation in `components/AboutMe.vue`, `components/Contact.vue`, `components/Experience.vue`, `components/Experiences.vue`, `components/Footer.vue`, `components/Hero.vue`, `components/ProjectCard.vue`, and `components/TheProjectsList.vue`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/quentin-aslan/quentin-aslan/pull/3?shareId=1a2ea7e3-cbb9-43bb-96a2-269a94ddfc44).